### PR TITLE
Register the process under the name automatically.

### DIFF
--- a/lib/transmission.ex
+++ b/lib/transmission.ex
@@ -1,5 +1,5 @@
 defmodule Transmission do
-  use ExActor.GenServer
+  use ExActor.GenServer, export: Transmission
 
   alias Transmission.Api
   alias Transmission.TorrentAdd


### PR DESCRIPTION
When starting the application in a Supervisor the name is not being registered. This solves that so you simply add

```
worker(Transmission, ["host", "user", "pass"])
```

to the supervision tree.